### PR TITLE
Fix 404 errors for GitLab nested groups.

### DIFF
--- a/src/main/java/com/capitalone/dashboard/gitlab/GitlabUrlUtility.java
+++ b/src/main/java/com/capitalone/dashboard/gitlab/GitlabUrlUtility.java
@@ -415,7 +415,7 @@ public class GitlabUrlUtility {
         if (gitlabSettings.isUseProjectId()) {
             repoName = projectIdValue;
         } else {
-            repoName = urlParts[0] + "%2F" + urlParts[1];
+            repoName = String.join("%2F", urlParts);
         }
 		return repoName;
 	}


### PR DESCRIPTION
Repo name was set as exactly 2 parts separated by a slash.
In the case of nested groups a repo no longer look like "hygieia/collector-gitlab-scm" but "hygieia/collector/gitlab-scm" leading to 404 error in API requests because only "hygieia/collector" were taken into account.
This proposal allows to handle as many nested group as needed by a project and fix #10 