### PR TITLE
Reuse same env var as sonar collector docker properties builder

### DIFF
--- a/docker/properties-builder.sh
+++ b/docker/properties-builder.sh
@@ -12,39 +12,20 @@ if [ "$TEST_SCRIPT" != "" ]
 then
   #for testing locally
   PROP_FILE=application.properties
-else 
-  PROP_FILE=/hygieia/config/application.properties
-fi
-  
-if [ "$MONGO_PORT" != "" ]; then
-	# Sample: MONGO_PORT=tcp://172.17.0.20:27017
-	MONGODB_HOST=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\1;'`
-	MONGODB_PORT=`echo $MONGO_PORT|sed 's;.*://\([^:]*\):\(.*\);\2;'`
 else
-	env
-	echo "ERROR: MONGO_PORT not defined"
-	exit 1
+  PROP_FILE=/hygieia/config/application.properties
 fi
 
 echo "MONGODB_HOST: $MONGODB_HOST"
 echo "MONGODB_PORT: $MONGODB_PORT"
 
-
 cat > $PROP_FILE <<EOF
 #Database Name
-dbname=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_DATABASE:-dashboarddb}
-
-#Database HostName - default is localhost
-dbhost=${MONGODB_HOST:-10.0.1.1}
-
-#Database Port - default is 27017
+dbname=${MONGODB_DATABASE:-dashboarddb}
+dbhost=${MONGODB_HOST:-db}
 dbport=${MONGODB_PORT:-27017}
-
-#Database Username - default is blank
-dbusername=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
-
-#Database Password - default is blank
-dbpassword=${HYGIEIA_API_ENV_SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
+dbusername=${MONGODB_USERNAME:-dashboarduser}
+dbpassword=${MONGODB_PASSWORD:-dbpassword}
 
 #Collector schedule (required)
 gitlab.cron=${GITLAB_CRON:-0 0/5 * * * *}


### PR DESCRIPTION
In order to normalize env var for collectors.
And remove useless MONGO_PORT env var, this not consistent and useless (my opinion)